### PR TITLE
Fix Datasets warning about generic parameters

### DIFF
--- a/src/pyeval/_core.py
+++ b/src/pyeval/_core.py
@@ -202,7 +202,7 @@ def dataset(*args: Case | str | Path) -> Callable[[Func], Func]:
             result.evaluate(EqualsExpected())
     """
     if len(args) == 1 and isinstance(args[0], (str, Path)):
-        cases: tuple[Case, ...] = tuple(Dataset.from_file(args[0]).cases)
+        cases: tuple[Case, ...] = tuple(Dataset[Any, Any, Any].from_file(args[0]).cases)
     else:
         cases = args  # type: ignore[assignment]
 


### PR DESCRIPTION

This fixes the Datasets warning

```
dataset.py:547: UserWarning: Could not determine the generic parameters for <class 'pydantic_evals.dataset.Dataset'>; using `Any` for each. You should explicitly set the generic parameters via `Dataset[MyInputs, MyOutput, MyMetadata]` when serializing or deserializing.
```