### PR TITLE
Fix issue with EvalItem.reportinfo() causing pytest error

### DIFF
--- a/src/pyeval/plugin.py
+++ b/src/pyeval/plugin.py
@@ -212,4 +212,6 @@ class EvalItem(pytest.Item):
     def reportinfo(self):
         parent_name = f"{self.parent.name}:" if self.parent is not None else ""
 
-        return self.fspath, None, f"{parent_name}{self.name}"
+        # 0 is the pytest convention for synthetic items with no source line —
+        # see https://docs.pytest.org/en/stable/example/nonpython.html
+        return self.fspath, 0, f"{parent_name}{self.name}"

--- a/tests/evals/eval_skipif.py
+++ b/tests/evals/eval_skipif.py
@@ -4,7 +4,10 @@ import pytest
 
 from pyeval import Case, dataset, execute
 
-pytestmark = pytest.mark.skipif(True, reason="always skipped — tests that EvalItem handles pytestmark skipif without INTERNALERROR")
+pytestmark = pytest.mark.skipif(
+    True,
+    reason="always skipped — tests that EvalItem handles pytestmark skipif without INTERNALERROR",
+)
 
 
 @dataset(

--- a/tests/evals/eval_skipif.py
+++ b/tests/evals/eval_skipif.py
@@ -14,4 +14,4 @@ pytestmark = pytest.mark.skipif(
     Case(name="skipped_case", inputs="hello", expected_output="hello"),
 )
 def eval_skipif_regression(case):
-    result = execute(lambda x: x, case)
+    execute(lambda x: x, case)

--- a/tests/evals/eval_skipif.py
+++ b/tests/evals/eval_skipif.py
@@ -1,0 +1,14 @@
+"""Regression test: pytestmark skipif must not cause INTERNALERROR."""
+
+import pytest
+
+from pyeval import Case, dataset, execute
+
+pytestmark = pytest.mark.skipif(True, reason="always skipped — tests that EvalItem handles pytestmark skipif without INTERNALERROR")
+
+
+@dataset(
+    Case(name="skipped_case", inputs="hello", expected_output="hello"),
+)
+def eval_skipif_regression(case):
+    result = execute(lambda x: x, case)


### PR DESCRIPTION

This fixes #15 by correcly returning the correct types from `reportinfo()`
