### PR TITLE
Add fail-fast to python-version matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:


### PR DESCRIPTION

This adds `fail-fast: false` to the testing matrix to ensure all versions of Python run to completeion

