### PR TITLE
Show score output in pytest report

### DIFF
--- a/src/pyeval/plugin.py
+++ b/src/pyeval/plugin.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import itertools
 import time
 import traceback
 from collections.abc import Callable
@@ -223,13 +224,20 @@ class EvalItem(pytest.Item):
             evaluator_failures=evaluator_failures,
         )
 
-        bool_results = list(assertions.values())
-        score = (
-            sum(1 for r in bool_results if r.value is True) / len(bool_results)
-            if bool_results
-            else 1.0
+        all_values = [
+            min(1.0, max(0.0, float(r.value)))
+            for r in itertools.chain(assertions.values(), scores.values())
+        ]
+        score = sum(all_values) / len(all_values) if all_values else 1.0
+
+        bool_icons = "".join(
+            "✔" if r.value is True else "✗" for r in assertions.values()
         )
-        icons = "".join("✔" if r.value is True else "✗" for r in bool_results)
+        score_icons = "".join(
+            _score_symbol(min(1.0, max(0.0, float(result.value))))[0]
+            for result in scores.values()
+        )
+        icons = bool_icons + score_icons
         self.user_properties.append(("eval_status", (*_score_symbol(score), icons)))
 
     def reportinfo(self):

--- a/tests/evals/eval_example.py
+++ b/tests/evals/eval_example.py
@@ -71,6 +71,7 @@ def eval_title_case_validation(case):
     result.evaluate(EqualsExpected())
     result.evaluate(Contains(value="H", evaluation_name="has_capitals"))
     result.evaluate(MaxDuration(seconds=0.001))
+    result.evaluate(CustomEvaluator())
 
 
 @dataset(


### PR DESCRIPTION

This updates the report output to take score results into account. In normal mode it treats assertions as `0.0` (`False`) and `1.0` (`True`) and averages the score with the score output. In verbose mode, they get shown inline with the assertions.

Closes #3 
